### PR TITLE
Fix mobile image lightbox links

### DIFF
--- a/src/app/folders/page.tsx
+++ b/src/app/folders/page.tsx
@@ -9,7 +9,7 @@ async function Folders() {
     <section className="flex flex-col justify-center sm:flex-row sm:my-20 sm:mt-48">
       <div className="max-sm:px-2 px-4 w-full max-w-6xl">
         <h1 className="font-semibold tracking-tight text-4xl mb-16 w-full text-gray-800">
-          Album Folders
+          Folders
         </h1>
 
         <ul className="flex flex-col justify-center items-start gap-5 mb-32">

--- a/src/lib/images/pig-grid.tsx
+++ b/src/lib/images/pig-grid.tsx
@@ -80,12 +80,13 @@ function PigGrid({ items }: { items: Array<Photo> }) {
           {items.map(item => (
             <a
               key={item.url}
-              data-pwsp-width={item.width}
-              data-pwsp-height={item.height}
+              href={item.url}
+              data-pswp-width={item.width}
+              data-pswp-height={item.height}
               target="_blank"
               rel="noreferrer"
             >
-              <img src={item.url} alt="" />
+              <img src={item.url} alt="" width={item.width} height={item.height} loading="lazy" decoding="async" />
             </a>
           ))}
         </div>


### PR DESCRIPTION


- Add the image URL as the mobile gallery anchor `href`
- Correct PhotoSwipe metadata from `data-pwsp-*` to `data-pswp-*`
- Add intrinsic image dimensions and async/lazy loading hints

